### PR TITLE
fixed Squeak link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Cuis](http://www.jvuletich.org/Cuis/Index.html) is a free Smalltalk-80 environment originally derived from [Squeak] (www.squeak.org) with a specific set of goals: being simple and powerful. It is also portable to any platform, fast and efficient. This means it is a great tool for running on any hardware, ranging from supercomputers to tablets and smart phones, and everything in between, including regular PCs.
+[Cuis](http://www.jvuletich.org/Cuis/Index.html) is a free Smalltalk-80 environment originally derived from [Squeak] (http://www.squeak.org) with a specific set of goals: being simple and powerful. It is also portable to any platform, fast and efficient. This means it is a great tool for running on any hardware, ranging from supercomputers to tablets and smart phones, and everything in between, including regular PCs.
 
 Cuis is:
     - Simple


### PR DESCRIPTION
Hi Juan,

Congratulations to the Cuis 4.1 release. This change should fix a broken link to the Squeak homepage.

Cheers,
Bernhard
